### PR TITLE
feat: add allowNewLines option

### DIFF
--- a/electron-src/events/handlers/saveChanges.js
+++ b/electron-src/events/handlers/saveChanges.js
@@ -97,6 +97,9 @@ exports.registerSaveChanges = function (window) {
                     }
                     value = trim(value);
                 }
+                if (!options.allowNewLines && isString(value)) {
+                    value = value.replace('\n', ' ');
+                }
                 return value;
             };
             Object.values(project.files).forEach(function (file) {

--- a/electron-src/events/handlers/saveChanges.ts
+++ b/electron-src/events/handlers/saveChanges.ts
@@ -57,6 +57,9 @@ export const registerSaveChanges = (window: BrowserWindow) => {
         }
         value = trim(value);
       }
+      if (!options.allowNewLines && isString(value)) {
+        value = value.replace('\n', ' ');
+      }
       return value;
     };
 

--- a/shared/translationInterfaces.ts
+++ b/shared/translationInterfaces.ts
@@ -27,6 +27,7 @@ export interface TranslationServiceOptions {
   trim: boolean;
   prettySource: boolean;
   disableNotes: boolean;
+  allowNewLines: boolean;
 }
 
 export interface Keyword {
@@ -51,7 +52,7 @@ export interface Collection {
   projects: CollectionProject[];
   options: {
 
-  }
+  };
 }
 
 export interface StorageItem {

--- a/src/app/components/toolbar/toolbar.component.html
+++ b/src/app/components/toolbar/toolbar.component.html
@@ -43,7 +43,7 @@
         aria-label="import CSV">
       </mat-icon>
     </button>
-    
+
     <button mat-icon-button
             aria-label="export as CSV"
             matTooltip="export as CSV"
@@ -148,6 +148,17 @@
             (click)="translation.setOption('disableNotes', !translation.options.disableNotes)">
       <mat-icon aria-label="Enable notes">
         add_comment
+      </mat-icon>
+    </button>
+
+    <button mat-icon-button
+            aria-label="Write newlines"
+            matTooltip="Write newlines"
+            [disabled]="translation.shouldDisableOption('allowNewLines')"
+            [color]="translation.options.allowNewLines ?  'accent' : undefined"
+            (click)="translation.setOption('allowNewLines', !translation.options.allowNewLines)">
+      <mat-icon aria-label="Allow newlines">
+        reorder
       </mat-icon>
     </button>
 

--- a/src/app/services/translations/translations.service.ts
+++ b/src/app/services/translations/translations.service.ts
@@ -22,7 +22,8 @@ export class TranslationsService {
   public _options: TranslationServiceOptions = {
     trim: false,
     prettySource: false,
-    disableNotes: false
+    disableNotes: false,
+    allowNewLines: true
   };
 
   public config = {


### PR DESCRIPTION
This adds a switch to allow newlines in the exported JSON file.